### PR TITLE
gzip all API requests

### DIFF
--- a/twitching.el
+++ b/twitching.el
@@ -1371,14 +1371,49 @@ GET."
                                        (append url-request-extra-headers headers)
                                      headers))
         (url-request-method (or request-method "GET"))
+        (url-mime-encoding-string "gzip")
         buffer
         response)
     (setq buffer (url-retrieve-synchronously url))
     (unwind-protect
         (with-current-buffer buffer
+          ;; check if response is gzipped and handle accordingly
+          (url-http-handle-decompression buffer)
           (setq response (buffer-string)))
       (kill-buffer buffer))
     response))
+
+(defun url-http-handle-decompression (response-buffer)
+  "Returns RESPONSE-BUFFER, decompressing its body if necessary.
+If RESPONSE-BUFFER contains the header \"Content-Encoding:
+gzip\", it is assumed that the body is gzip'd and that portion is
+gunzip'd.
+
+This function always returns the RESPONSE-BUFFER."
+  (with-current-buffer response-buffer
+    (goto-char (point-min))
+    (let* ((noerror t)
+           (header-end (progn (search-forward "\n\n" nil noerror 1) (point)))
+           (gzippedp (progn
+                       (goto-char (point-min))
+                       (search-forward-regexp "^content-encoding: *gzip$"
+                                              header-end noerror 1))))
+      (when gzippedp
+        (let ((filename (make-temp-file "response" nil ".gz"))
+              contents)
+          (unwind-protect
+              (progn
+                (write-region header-end (point-max) filename nil nil)
+                (with-auto-compression-mode
+                  (let ((buffer (find-file filename)))
+                    (setq contents (buffer-string))
+                    (kill-buffer buffer))))
+            (delete-file filename nil))
+          (with-current-buffer response-buffer
+            (delete-region header-end (point-max))
+            (goto-char header-end)
+            (insert contents))))
+      response-buffer)))
 
 (defun url-get-http-status-code (response)
   "Return the http status code in RESPONSE.  Return nil if


### PR DESCRIPTION
Earlier each request would be around 430K but now they're
only 46K.  A huge saving in bandwidth and, consequently,
time.